### PR TITLE
feat(tonic): implement global input object validation using go-playground/validator

### DIFF
--- a/tonic/README
+++ b/tonic/README
@@ -10,11 +10,28 @@ Here is an example input object.
 
     type MyInput struct {
         Foo int    `path:"foo,required"`
-        Bar float  `query:"bar,default=foobar"`
-        Baz string `json:"baz" binding:"required"`
+        Bar string `query:"bar,default=foobar"`
+        Baz string `json:"baz"`
     }
 
 Output objects can be of any type, and will be marshaled to JSON.
+
+Input validation is performed after binding into the object using the validator library
+(https://github.com/go-playground/validator). You can use the tag 'validate' on your object
+definition to perform validation inside the tonic handler phase.
+
+    type MyInput struct {
+        Foo int    `path:"foo,required" validate:"required,gt=10`
+        Bar string `query:"bar,default=foobar" validate:"nefield=Baz"`
+        Baz string `json:"baz" validate:"required,email"`
+    }
+
+enum input validation is also implemented natively by tonic, and can check that the provided input
+value corresponds to one of the expected enum values.
+
+    type MyInput struct {
+        Bar string `query:"bar" enum:"foo,buz,biz"`
+    }
 
 The handler can return an error, which will be returned to the caller.
 
@@ -74,7 +91,7 @@ Example of the same application as before, using juju errors:
     )
 
     type GreetUserInput struct {
-        Name string `path:"name,required" description:"User name"`
+        Name string `path:"name,required" validate:"gt=3" description:"User name"`
     }
 
     type GreetUserOutput struct {

--- a/tonic/README
+++ b/tonic/README
@@ -21,7 +21,7 @@ Input validation is performed after binding into the object using the validator 
 definition to perform validation inside the tonic handler phase.
 
     type MyInput struct {
-        Foo int    `path:"foo,required" validate:"required,gt=10`
+        Foo int    `path:"foo,required" validate:"required,gt=10"`
         Bar string `query:"bar,default=foobar" validate:"nefield=Baz"`
         Baz string `json:"baz" validate:"required,email"`
     }

--- a/tonic/tonic.go
+++ b/tonic/tonic.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/satori/go.uuid"
+	validator "gopkg.in/go-playground/validator.v8"
 )
 
 const (
@@ -269,6 +270,12 @@ func Handler(f interface{}, retcode int, options ...func(*Route)) gin.HandlerFun
 				handleError(c, InputError(err.Error()))
 				return
 			}
+			// validating query and path inputs if they have a validate tag
+			validatorObj := validator.New(&validator.Config{TagName: "validate"})
+			if err = validatorObj.Struct(input.Interface()); err != nil {
+				handleError(c, InputError(fmt.Sprintf("invalid input parameters: %s", err.Error())))
+				return
+			}
 			funcIn = append(funcIn, input)
 		}
 
@@ -314,7 +321,7 @@ func Description(s string) func(*Route) {
 	}
 }
 
-// Description set the summary of a route.
+// Summary set the summary of a route.
 func Summary(s string) func(*Route) {
 	return func(r *Route) {
 		r.summary = s

--- a/tonic/tonic_test.go
+++ b/tonic/tonic_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -94,10 +95,13 @@ func TestBody(t *testing.T) {
 
 	tester := iffy.NewTester(t, r)
 
-	tester.AddCall("body", "POST", "/body", `{"param": "foo"}`).Checkers(iffy.ExpectStatus(200), expectString("param", "foo"))
-	tester.AddCall("body", "POST", "/body", `{}`).Checkers(iffy.ExpectStatus(400))
-	tester.AddCall("body", "POST", "/body", `{"param": ""}`).Checkers(iffy.ExpectStatus(400))
-	tester.AddCall("body", "POST", "/body", `{"param": "foo", "param-optional": "bar"}`).Checkers(iffy.ExpectStatus(200), expectString("param-optional", "bar"))
+	tester.AddCall("body1", "POST", "/body", `{"param": "foo"}`).Checkers(iffy.ExpectStatus(200), expectString("param", "foo"))
+	tester.AddCall("body2", "POST", "/body", `{}`).Checkers(iffy.ExpectStatus(400))
+	tester.AddCall("body3", "POST", "/body", `{"param": ""}`).Checkers(iffy.ExpectStatus(400))
+	tester.AddCall("body4", "POST", "/body", `{"param": "foo", "param-optional": "bar"}`).Checkers(iffy.ExpectStatus(200), expectString("param-optional", "bar"))
+	tester.AddCall("body5", "POST", "/body", `{"param": "foo", "param-optional-validated": "ttttt"}`).Checkers(iffy.ExpectStatus(400), expectStringInBody("failed on the 'eq|eq|gt' tag"))
+	tester.AddCall("body6", "POST", "/body", `{"param": "foo", "param-optional-validated": "foo"}`).Checkers(iffy.ExpectStatus(200), expectString("param-optional-validated", "foo"))
+	tester.AddCall("body7", "POST", "/body", `{"param": "foo", "param-optional-validated": "foobarfoobuz"}`).Checkers(iffy.ExpectStatus(200), expectString("param-optional-validated", "foobarfoobuz"))
 
 	tester.Run()
 }
@@ -147,8 +151,9 @@ func queryHandler(c *gin.Context, in *queryIn) (*queryIn, error) {
 }
 
 type bodyIn struct {
-	Param         string `json:"param" binding:"required"`
-	ParamOptional string `json:"param-optional"`
+	Param                  string `json:"param" validate:"required"`
+	ParamOptional          string `json:"param-optional"`
+	ValidatedParamOptional string `json:"param-optional-validated" validate:"eq=|eq=foo|gt=10"`
 }
 
 func bodyHandler(c *gin.Context, in *bodyIn) (*bodyIn, error) {
@@ -233,6 +238,16 @@ func expectStringArr(paramName string, value ...string) func(*http.Response, str
 			if sArr[n] != value[n] {
 				return fmt.Errorf("%s: %s does not match", paramName, sArr[n])
 			}
+		}
+		return nil
+	}
+}
+
+func expectStringInBody(value string) func(*http.Response, string, interface{}) error {
+
+	return func(r *http.Response, body string, obj interface{}) error {
+		if !strings.Contains(body, value) {
+			return fmt.Errorf("body doesn't contains '%s'", value)
 		}
 		return nil
 	}

--- a/tonic/utils/swag/helpers.go
+++ b/tonic/utils/swag/helpers.go
@@ -10,8 +10,14 @@ import (
 )
 
 const (
-	query_tag = "query"
-	path_tag  = "path"
+	queryTag         = "query"
+	pathTag          = "path"
+	bindingTag       = "binding" // deprecated, should not be used anymore
+	validateTag      = "validate"
+	jsonTag          = "json"
+	descriptionTag   = "description"
+	swaggerTypeTag   = "swagger-type"
+	requiredProperty = "required"
 )
 
 func getFieldName(field reflect.StructField) *string {
@@ -27,15 +33,15 @@ func getFieldName(field reflect.StructField) *string {
 
 func paramName(f reflect.StructField) string {
 	var tag string
-	qTag := f.Tag.Get(query_tag)
+	qTag := f.Tag.Get(queryTag)
 	if qTag != "" {
 		tag = qTag
 	}
-	pTag := f.Tag.Get(path_tag)
+	pTag := f.Tag.Get(pathTag)
 	if pTag != "" {
 		tag = pTag
 	}
-	jTag := f.Tag.Get("json")
+	jTag := f.Tag.Get(jsonTag)
 	if jTag != "" {
 		tag = jTag
 	}
@@ -51,45 +57,49 @@ func paramName(f reflect.StructField) string {
 }
 
 func paramDescription(f reflect.StructField) string {
-	return f.Tag.Get("description")
+	return f.Tag.Get(descriptionTag)
 }
 
 func paramRequired(f reflect.StructField) bool {
 	var tag string
-	qTag := f.Tag.Get(query_tag)
+	qTag := f.Tag.Get(queryTag)
 	if qTag != "" {
 		tag = qTag
 	}
-	pTag := f.Tag.Get(path_tag)
+	pTag := f.Tag.Get(pathTag)
 	if pTag != "" {
 		tag = pTag
 	}
-	bTag := f.Tag.Get("binding")
+	bTag := f.Tag.Get(bindingTag)
 	if bTag != "" {
 		tag = bTag
 	}
-	return strings.Index(tag, "required") != -1
+	vTag := f.Tag.Get(validateTag)
+	if vTag != "" {
+		tag = vTag
+	}
+	return strings.Index(tag, requiredProperty) != -1
 }
 
 func paramType(f reflect.StructField) string {
-	qTag := f.Tag.Get(query_tag)
+	qTag := f.Tag.Get(queryTag)
 	if qTag != "" {
-		return query_tag
+		return queryTag
 	}
-	pTag := f.Tag.Get(path_tag)
+	pTag := f.Tag.Get(pathTag)
 	if pTag != "" {
-		return path_tag
+		return pathTag
 	}
 	return "body"
 }
 
 func paramsDefault(f reflect.StructField) string {
 	var tag string
-	qTag := f.Tag.Get(query_tag)
+	qTag := f.Tag.Get(queryTag)
 	if qTag != "" {
 		tag = qTag
 	}
-	pTag := f.Tag.Get(path_tag)
+	pTag := f.Tag.Get(pathTag)
 	if pTag != "" {
 		tag = pTag
 	}
@@ -119,10 +129,10 @@ func paramTargetTypeAllowMultiple(f reflect.StructField) (reflect.Type, bool) {
 
 func paramFormatDataTypeRefId(f reflect.StructField) (string, string, string) {
 	var format, dataType, refId string
-	if f.Tag.Get("swagger-type") != "" {
+	if f.Tag.Get(swaggerTypeTag) != "" {
 		//Swagger type defined on the original struct, no need to infer it
 		//format is: swagger-type:type[,format]
-		tagValue := f.Tag.Get("swagger-type")
+		tagValue := f.Tag.Get(swaggerTypeTag)
 		tagTypes := strings.Split(tagValue, ",")
 		switch len(tagTypes) {
 		case 1:
@@ -131,7 +141,7 @@ func paramFormatDataTypeRefId(f reflect.StructField) (string, string, string) {
 			dataType = tagTypes[0]
 			format = tagTypes[1]
 		default:
-			panic(fmt.Sprintf("Error: bad swagger-type definition on %s (%s)", f.Name, tagValue))
+			panic(fmt.Sprintf("Error: bad %s definition on %s (%s)", swaggerTypeTag, f.Name, tagValue))
 		}
 	} else {
 		targetType, _ := paramTargetTypeAllowMultiple(f)


### PR DESCRIPTION
After binding every parameters (path, query, body), a input validation
will be performed on every fields using go-playground/validator standard
tag.

Field object should be tagged with `validate` in order to be checked
while handling the request.

Also adding documentation about 'enum' tag, and refactoring swagger
generator as we are not using 'binding' tag anymore.

Signed-off-by: Romain Beuque <romain.beuque@corp.ovh.com>