### PR TITLE
Better json response support

### DIFF
--- a/iffy/iffy.go
+++ b/iffy/iffy.go
@@ -113,7 +113,8 @@ func (t *Tester) Run() {
 					t.t.Error(err)
 				}
 			}
-			var retJson map[string]interface{}
+
+			var retJson interface{}
 			err = json.Unmarshal(rb, &retJson)
 			if err == nil {
 				t.values[c.Name] = retJson

--- a/iffy/iffy.go
+++ b/iffy/iffy.go
@@ -114,8 +114,11 @@ func (t *Tester) Run() {
 				}
 			}
 
+			dec := json.NewDecoder(bytes.NewBuffer(rb))
+			dec.UseNumber()
+
 			var retJson interface{}
-			err = json.Unmarshal(rb, &retJson)
+			err = dec.Decode(&retJson)
 			if err == nil {
 				t.values[c.Name] = retJson
 			}


### PR DESCRIPTION
When chaining multiple calls and reusing outputs from previous calls, there are times when it does not return a JSON object.

This pull request aims to alleviate this by simply decoding into an `interface{}` and not assume the response is a JSON object. I also replaced the `json.Unmarshal` call with a `json.Decoder` to take advantage of `UseNumber()`.

This allows to write chained calls like:

```go
...

tester := iffy.NewTester(t, someHandler)

tester.
    AddCall("createResource", http.MethodPost, "/resource", `{"name":"test"}`).
    Checkers(
        iffy.ExpectStatus(http.StatusCreated),
    )

tester.
    AddCall("listResource", http.MethodGet, "/resource", "").
    Checkers(
        iffy.ExpectStatus(http.StatusOK),
        iffy.ExpectListLength(1),
    )

// Here, we have 'listResource' in our template context which is an array
tester.
    AddCall("getResource", http.MethodGet, "/resource/{{(index .listResource 0).id}}", "").
    Checkers(
        iffy.ExpectStatus(http.StatusOK),
        iffy.ExpectJSONFields("id", "name"),
    )

...
```