### PR TITLE
Moving 'MaxBodyBytes' from const to var

### DIFF
--- a/tonic/tonic.go
+++ b/tonic/tonic.go
@@ -17,7 +17,7 @@ import (
 )
 
 // MaxBodyBytes is the maximum allowed size of a request body in bytes.
-const MaxBodyBytes = 256 * 1024
+var MaxBodyBytes = 256 * 1024
 
 // Fields tags used by tonic.
 const (

--- a/tonic/tonic.go
+++ b/tonic/tonic.go
@@ -17,7 +17,7 @@ import (
 )
 
 // MaxBodyBytes is the maximum allowed size of a request body in bytes.
-var MaxBodyBytes = 256 * 1024
+var MaxBodyBytes int64 = 256 * 1024
 
 // Fields tags used by tonic.
 const (


### PR DESCRIPTION
This way we can manually specify the max body size for our own applications