### PR TITLE
feat: provide a RegisterTagNameFunc()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *TODO*
+.history/

--- a/tonic/handler.go
+++ b/tonic/handler.go
@@ -150,6 +150,21 @@ func RegisterValidation(tagName string, validationFunc validator.Func) error {
 	return validatorObj.RegisterValidation(tagName, validationFunc)
 }
 
+// RegisterTagNameFunc registers a function to get alternate names for StructFields.
+//
+// eg. to use the names which have been specified for JSON representations of structs, rather than normal Go field names:
+//
+//    validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
+//        name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+//        if name == "-" {
+//            return ""
+//        }
+//        return name
+//    }
+func RegisterTagNameFunc(registerTagFunc validator.TagNameFunc) {
+	validatorObj.RegisterTagNameFunc(registerTagFunc)
+}
+
 func initValidator() {
 	validatorOnce.Do(func() {
 		validatorObj = validator.New()


### PR DESCRIPTION
Provide a public RegisterTagNameFunc in `handler.go`. So
clients of Tonic, can register their own tag functions.

Fixes #71