### PR TITLE
Allows the SetRenderHook to override the mediaType

### DIFF
--- a/tonic/tonic.go
+++ b/tonic/tonic.go
@@ -139,7 +139,7 @@ func GetRoutes() map[string]*Route {
 // MediaType returns the current media type (MIME)
 // used by the actual render hook.
 func MediaType() string {
-	return defaultMediaType
+	return mediaType
 }
 
 // GetErrorHook returns the current error hook.


### PR DESCRIPTION
The `MediaType()` function did always return the `defaultMediaType` instead of the currently active `mediaType`.