### PR TITLE
Add initValidator in RegisterTagNameFunc to prevent panic

### DIFF
--- a/tonic/handler.go
+++ b/tonic/handler.go
@@ -162,6 +162,7 @@ func RegisterValidation(tagName string, validationFunc validator.Func) error {
 //        return name
 //    }
 func RegisterTagNameFunc(registerTagFunc validator.TagNameFunc) {
+	initValidator()
 	validatorObj.RegisterTagNameFunc(registerTagFunc)
 }
 


### PR DESCRIPTION
Calling `tonic.RegisterTagNameFunc` results in the following panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd6823e]

goroutine 1 [running]:
github.com/go-playground/validator/v10.(*Validate).RegisterTagNameFunc(...)
	/home/edgar/go/pkg/mod/github.com/go-playground/validator/v10@v10.11.2/validator_instance.go:202
github.com/loopfz/gadgeto/tonic.RegisterTagNameFunc(...)
	/home/edgar/go/pkg/mod/github.com/loopfz/gadgeto@v0.11.2/tonic/handler.go:165
```