### PR TITLE
Register a custom type func for validation

### DIFF
--- a/tonic/handler.go
+++ b/tonic/handler.go
@@ -150,6 +150,15 @@ func RegisterValidation(tagName string, validationFunc validator.Func) error {
 	return validatorObj.RegisterValidation(tagName, validationFunc)
 }
 
+// RegisterCustomTypeFunc registers a CustomTypeFunc against a number of types
+// on the validator.Validate instance of the package
+// NOTE: calling this function may instantiate the validator itself.
+// NOTE: this method is not thread-safe it is intended that these all be registered prior to any validation
+func RegisterCustomTypeFunc(validationFunc validator.CustomTypeFunc, types ...interface{}) {
+	initValidator()
+	validatorObj.RegisterCustomTypeFunc(validationFunc, types)
+}
+
 // RegisterTagNameFunc registers a function to get alternate names for StructFields.
 //
 // eg. to use the names which have been specified for JSON representations of structs, rather than normal Go field names:


### PR DESCRIPTION
Since a recent version of go-playground/validator, it's no longer possible to validate a struct that implement the Valuer interface. For this purpose, the project maintainer advises writing a custom pre-validation function to extract the field content to validate.

https://github.com/go-playground/validator/blob/master/_examples/custom/main.go