### PR TITLE
Expose access to validator to support translations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/loopfz/gadgeto
+module github.com/jonbango/gadgeto
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jonbango/gadgeto
+module github.com/loopfz/gadgeto
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/assert/v2 v2.2.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-sql-driver/mysql v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=

--- a/tonic/handler.go
+++ b/tonic/handler.go
@@ -18,16 +18,21 @@ var (
 	validatorOnce sync.Once
 )
 
+func GetValidator() *validator.Validate {
+	initValidator()
+	return validatorObj
+}
+
 // Handler returns a Gin HandlerFunc that wraps the handler passed
 // in parameters.
 // The handler may use the following signature:
 //
-//  func(*gin.Context, [input object ptr]) ([output object], error)
+//	func(*gin.Context, [input object ptr]) ([output object], error)
 //
 // Input and output objects are both optional.
 // As such, the minimal accepted signature is:
 //
-//  func(*gin.Context) error
+//	func(*gin.Context) error
 //
 // The wrapping gin-handler will bind the parameters from the query-string,
 // path, body and headers, and handle the errors.
@@ -154,13 +159,13 @@ func RegisterValidation(tagName string, validationFunc validator.Func) error {
 //
 // eg. to use the names which have been specified for JSON representations of structs, rather than normal Go field names:
 //
-//    tonic.RegisterTagNameFunc(func(fld reflect.StructField) string {
-//        name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
-//        if name == "-" {
-//            return ""
-//        }
-//        return name
-//    })
+//	tonic.RegisterTagNameFunc(func(fld reflect.StructField) string {
+//	    name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+//	    if name == "-" {
+//	        return ""
+//	    }
+//	    return name
+//	})
 func RegisterTagNameFunc(registerTagFunc validator.TagNameFunc) {
 	initValidator()
 	validatorObj.RegisterTagNameFunc(registerTagFunc)

--- a/tonic/tonic_test.go
+++ b/tonic/tonic_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/assert/v2"
+
 	"github.com/loopfz/gadgeto/iffy"
 	"github.com/loopfz/gadgeto/tonic"
 )
@@ -128,6 +130,13 @@ func TestBody(t *testing.T) {
 	tester.AddCall("body7", "POST", "/body", `{"param": "foo", "param-optional-validated": "foobarfoobuz"}`).Checkers(iffy.ExpectStatus(200), expectString("param-optional-validated", "foobarfoobuz"))
 
 	tester.Run()
+}
+
+func Test_EnsureIdenticalValidatorReference(t *testing.T) {
+	validatorFirstCall := tonic.GetValidator()
+	validatorSecondCall := tonic.GetValidator()
+
+	assert.Equal(t, validatorFirstCall, validatorSecondCall)
 }
 
 func errorHandler(c *gin.Context) error {


### PR DESCRIPTION
In order to support translations for the go-playground validator (see [here](https://github.com/go-playground/validator/tree/master/translations)) the validator that is used in the tonic handler must be exposed to enable registration of the default / custom translations by the consuming project.

